### PR TITLE
Update Packer.php so that you can pass in a Logger

### DIFF
--- a/Packer.php
+++ b/Packer.php
@@ -10,6 +10,7 @@
   use Psr\Log\LoggerAwareTrait;
   use Psr\Log\LogLevel;
   use Psr\Log\NullLogger;
+  use Psr\Log\LoggerInterface;
 
   /**
    * Actual packer
@@ -33,12 +34,13 @@
 
     /**
      * Constructor
+     * @param LoggerInterface $logger
      */
-    public function __construct() {
+    public function __construct(LoggerInterface $logger = null) {
       $this->items = new ItemList();
       $this->boxes = new BoxList();
 
-      $this->logger = new NullLogger();
+      ($logger) ? $this->setLogger($logger) : $this->setLogger(new NullLogger());
     }
 
     /**


### PR DESCRIPTION
Currently no way of using Dependancy Injection to override the default NullLogger, this change will allow you to pass in a Logger implementation that uses the Psr Log LoggerInterface.

As you're using the LoggerAwareTrait we don't need to specifically set it using `$this->logger = new NullLogger();` and this now uses the appropriate `setLogger()` method exposed by the Trait.

I'm currently using the package in Laravel, so I can now do:

```
$packer = new DVDoug\BoxPacker\Packer(Log::getMonolog());
```

Thanks for your time & effor on this great package!
